### PR TITLE
Send options in templateSelection

### DIFF
--- a/select2.multi-checkboxes.js
+++ b/select2.multi-checkboxes.js
@@ -20,7 +20,7 @@
       placeholder: options.placeholder,
       closeOnSelect: false,
       templateSelection: function() {
-        return self.options.templateSelection(self.$element.val() || [], $('option', self.$element).length);
+        return self.options.templateSelection($('option:selected', self.$element) || [], $('option', self.$element).length);
       },
       templateResult: function(result) {
         if (result.loading !== undefined)


### PR DESCRIPTION
With the current version it's not possible to retrieve the label. I wanted to present results using a coma separated list.

```js
  templateSelection: function (selected) {
    return selected.map(function (i, option) {
      return option.innerText
    }).get().join(', ')
  }
```