### PR TITLE
Apply css class options to original select2 field

### DIFF
--- a/select2.multi-checkboxes.js
+++ b/select2.multi-checkboxes.js
@@ -15,6 +15,8 @@
 	var values = self.$element.val();
     self.$element.removeAttr('multiple');
     self.select2 = self.$element.select2({
+      dropdownCssClass: options.dropdownCssClass,
+      selectionCssClass: options.selectionCssClass,
       allowClear: true,
       minimumResultsForSearch: options.minimumResultsForSearch,
       placeholder: options.placeholder,


### PR DESCRIPTION
Allow to pass dropdownCssClass and selectionCssClass option to select2MultiCheckboxes and apply the values to the original select2 initialization