### PR TITLE
Add dropdownParent options

### DIFF
--- a/select2.multi-checkboxes.js
+++ b/select2.multi-checkboxes.js
@@ -19,6 +19,7 @@
       minimumResultsForSearch: options.minimumResultsForSearch,
       placeholder: options.placeholder,
       closeOnSelect: false,
+	  dropdownParent: options.dropdownParent || '',
       templateSelection: function() {
         return self.options.templateSelection(self.$element.val() || [], $('option', self.$element).length);
       },


### PR DESCRIPTION
Add dropdownParent option of select2.

Allows customize the style of the select2 without affecting the general style defined  in other select2s in the app, as it is in a container.